### PR TITLE
v1.1.2 - error handling related to messages stream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-twilio',
-      version='1.1.1',
+      version='1.1.2',
       description='Singer.io tap for extracting data from the Twilio API - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-twilio',
-      version='1.1.2',
+      version='1.1.2-airbyte',
       description='Singer.io tap for extracting data from the Twilio API - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_twilio/sync.py
+++ b/tap_twilio/sync.py
@@ -359,6 +359,16 @@ def sync_endpoint(
                                 'replication_keys', [])), None)
 
                             if child_path:
+                                if child_stream_name == "messages":
+                                    st_date = datetime.strptime('2020-01-01T00:00:00Z', "%Y-%m-%dT%H:%M:%SZ")
+                                    if (datetime.now() - st_date).days > 399:
+                                        new_start_date = datetime.now() - timedelta(days=399)
+                                        start_date = datetime.strftime(new_start_date, "%Y-%m-%dT%H:%M:%SZ")
+                                        LOGGER.info(
+                                            'Changed start_date for "messages" stream to {}, '
+                                            'because messages are only stored for the last 400 days'.format(start_date)
+                                        )
+
                                 child_total_records = sync_endpoint(
                                     client=client,
                                     config=config,

--- a/tap_twilio/sync.py
+++ b/tap_twilio/sync.py
@@ -360,7 +360,7 @@ def sync_endpoint(
 
                             if child_path:
                                 if child_stream_name == "messages":
-                                    st_date = datetime.strptime('2020-01-01T00:00:00Z', "%Y-%m-%dT%H:%M:%SZ")
+                                    st_date = datetime.strptime(start_date, "%Y-%m-%dT%H:%M:%SZ")
                                     if (datetime.now() - st_date).days > 399:
                                         new_start_date = datetime.now() - timedelta(days=399)
                                         start_date = datetime.strftime(new_start_date, "%Y-%m-%dT%H:%M:%SZ")

--- a/tap_twilio/sync.py
+++ b/tap_twilio/sync.py
@@ -359,6 +359,8 @@ def sync_endpoint(
                                 'replication_keys', [])), None)
 
                             if child_path:
+                                # Checking for the start date of reading "messages" stream,
+                                # it should not be more than 400 days before now
                                 if child_stream_name == "messages":
                                     st_date = datetime.strptime(start_date, "%Y-%m-%dT%H:%M:%SZ")
                                     if (datetime.now() - st_date).days > 399:


### PR DESCRIPTION
## Problem

The stream of messages break when there was an attempt to receive messages more than 400 days ago.
